### PR TITLE
Fix syntax error in Bylaws

### DIFF
--- a/bylaws.tex
+++ b/bylaws.tex
@@ -130,7 +130,7 @@ A Senator will be responsible for meeting the following requirements:
         \item The “Status Update” shall consist of:
         \begin{enumerate}
             \item Evidence that the Senator has completed or attempted to complete their initiative of the current month.
-            \itemA declaration of a new initiative or redeclaration of a current initiative for the next month.
+            \item A declaration of a new initiative or redeclaration of a current initiative for the next month.
         \end{enumerate}
         \item A Senator must submit a Status Update to the Oversight Committee for approval the last seven days before the end of the month.
         \begin{enumerate}


### PR DESCRIPTION
xetex compilation fails due to syntax error (`\itemA` instead of `\item A`)